### PR TITLE
Remove author filtering for GitLab commit statuses

### DIFF
--- a/src/validation/testcase/gitlab.py
+++ b/src/validation/testcase/gitlab.py
@@ -43,50 +43,37 @@ class GitlabTestcase(Testcase):
             },
         )
 
-    def _check_status_author(self, status: CommitFlag) -> bool:
-        """
-        Check if status author matches the account name.
-        Returns True if match, False otherwise (including on errors).
-        """
-        try:
-            if not status._raw_commit_flag or not status._raw_commit_flag.author:
-                return False
-            author_username = status._raw_commit_flag.author["username"]
-            logging.debug(
-                "Status '%s' by '%s' - Match: %s",
-                status.context,
-                author_username,
-                author_username == self.account_name,
-            )
-            return author_username == self.account_name
-        except (KeyError, AttributeError, TypeError) as e:
-            logging.warning(
-                "Failed to get author for status %s: %s - Raw: %s",
-                status.context,
-                e,
-                status._raw_commit_flag,
-            )
-            return False
-
     def get_statuses(self) -> list[CommitFlag]:
         all_statuses = list(self.project.get_commit_statuses(commit=self.head_commit))
 
         logging.debug(
-            "Fetching statuses for commit %s, looking for author: %s",
+            "Fetching statuses for commit %s, total found: %d",
             self.head_commit,
-            self.account_name,
-        )
-
-        filtered_statuses = [status for status in all_statuses if self._check_status_author(status)]
-
-        logging.debug(
-            "Found %d/%d statuses from %s",
-            len(filtered_statuses),
             len(all_statuses),
-            self.account_name,
         )
 
-        return filtered_statuses
+        # Log all statuses with their authors for debugging
+        for status in all_statuses:
+            author = "unknown"
+            try:
+                if status._raw_commit_flag and status._raw_commit_flag.author:
+                    author = status._raw_commit_flag.author.get("username", "unknown")
+            except (KeyError, AttributeError):
+                pass
+            logging.debug(
+                "Status '%s' by '%s' - state: %s",
+                status.context,
+                author,
+                status.state,
+            )
+
+        # GitLab pipeline statuses may not have the service account as author
+        logging.info(
+            "Returning all %d statuses for GitLab (not filtering by author)",
+            len(all_statuses),
+        )
+
+        return all_statuses
 
     def is_status_successful(self, status: CommitFlag) -> bool:
         return status.state == CommitStatus.success


### PR DESCRIPTION
The previous implementation filtered GitLab commit statuses by author, expecting all statuses to be created by the Packit service account. However, GitLab CI pipeline statuses are authored by the commit author or project owner, not by external service accounts. 
Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>
